### PR TITLE
[codex] Remove texto sobre código de atendimento

### DIFF
--- a/public/politica-de-privacidade.html
+++ b/public/politica-de-privacidade.html
@@ -68,13 +68,6 @@
       serão armazenados.
     </p>
 
-    <h2>Código de atendimento</h2>
-    <p>
-      Ao abrir uma conversa no WhatsApp, o site gera um código aleatório no formato
-      CT-XXXXXX. Esse código ajuda a relacionar o clique ao atendimento confirmado sem
-      registrar informações clínicas na planilha de conversões.
-    </p>
-
     <h2>Gerenciamento de preferências</h2>
     <p>
       Você pode aceitar, rejeitar ou alterar cookies opcionais pelo link Gerenciar cookies


### PR DESCRIPTION
﻿## O que mudou

- Remove da política de privacidade a seção "Código de atendimento".

## Validação

- npm.cmd run build
- Busca local confirmou que o bloco e os termos associados não aparecem mais na política.
